### PR TITLE
Switch to `wordpress-rest-api-oauth-1` as an "api client"

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -13,6 +13,14 @@ var _keyBy = require('lodash/keyBy');
 
 var _keyBy2 = _interopRequireDefault(_keyBy);
 
+var _qs = require('qs');
+
+var _qs2 = _interopRequireDefault(_qs);
+
+var _wordpressRestApiOauth = require('wordpress-rest-api-oauth-1');
+
+var _wordpressRestApiOauth2 = _interopRequireDefault(_wordpressRestApiOauth);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
@@ -23,7 +31,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  */
 
 
-var site = require('wpapi')({ endpoint: SiteSettings.endpoint, nonce: SiteSettings.nonce });
+var api = new _wordpressRestApiOauth2.default({
+	url: SiteSettings.endpoint
+});
 
 /**
  * Comment actions
@@ -177,12 +187,19 @@ function requestComments(postId) {
 			postId: postId
 		});
 
-		return site.comments().forPost(postId).order('asc').then(function (data) {
-			dispatch({
-				type: COMMENTS_REQUEST_SUCCESS,
-				comments: data,
-				count: data._paging.total,
-				postId: postId
+		var query = {
+			order: 'asc',
+			post: postId
+		};
+
+		api.get('/wp/v2/comments', query).then(function (comments) {
+			requestPageCount('/wp/v2/comments', query).then(function (count) {
+				dispatch({
+					type: COMMENTS_REQUEST_SUCCESS,
+					comments: comments,
+					count: count,
+					postId: postId
+				});
 			});
 			return null;
 		}).catch(function (error) {
@@ -208,7 +225,7 @@ function submitComment(comment) {
 			postId: comment.post
 		});
 
-		return site.comments().post(comment).then(function (data) {
+		api.post('/wp/v2/comments', comment).then(function (data) {
 			dispatch({
 				type: COMMENT_SUBMIT_REQUEST_SUCCESS,
 				comment: data,
@@ -224,4 +241,33 @@ function submitComment(comment) {
 			return error;
 		});
 	};
+}
+
+// Helper to grab the page count off the header
+function requestPageCount(url) {
+	var data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+
+	if (url.indexOf('http') !== 0) {
+		url = api.config.url + 'wp-json' + url;
+	}
+
+	if (data) {
+		// must be decoded before being passed to ouath
+		url += '?' + decodeURIComponent(_qs2.default.stringify(data));
+		data = null;
+	}
+
+	var headers = {
+		'Accept': 'application/json',
+		'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+	};
+
+	return fetch(url, {
+		method: 'HEAD',
+		headers: headers,
+		mode: 'cors',
+		body: null
+	}).then(function (response) {
+		return parseInt(response.headers.get('X-WP-TotalPages'), 10) || 1;
+	});
 }

--- a/lib/state.js
+++ b/lib/state.js
@@ -198,7 +198,7 @@ function requestComments(postId) {
 		};
 
 		api.get('/wp/v2/comments', query).then(function (comments) {
-			requestPageCount('/wp/v2/comments', query).then(function (count) {
+			requestCommentCount('/wp/v2/comments', query).then(function (count) {
 				dispatch({
 					type: COMMENTS_REQUEST_SUCCESS,
 					comments: comments,
@@ -248,8 +248,8 @@ function submitComment(comment) {
 	};
 }
 
-// Helper to grab the page count off the header
-function requestPageCount(url) {
+// Helper to grab the total comment count off the header
+function requestCommentCount(url) {
 	var data = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
 
 	if (url.indexOf('http') !== 0) {
@@ -273,7 +273,7 @@ function requestPageCount(url) {
 		mode: 'cors',
 		body: null
 	}).then(function (response) {
-		return parseInt(response.headers.get('X-WP-TotalPages'), 10) || 1;
+		return parseInt(response.headers.get('X-WP-Total'), 10);
 	});
 }
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -4,6 +4,11 @@ Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 exports.COMMENT_SUBMIT_REQUEST_FAILURE = exports.COMMENT_SUBMIT_REQUEST_SUCCESS = exports.COMMENT_SUBMIT_REQUEST = exports.COMMENTS_REQUEST_FAILURE = exports.COMMENTS_REQUEST_SUCCESS = exports.COMMENTS_REQUEST = undefined;
+exports.items = items;
+exports.itemsOnPost = itemsOnPost;
+exports.requests = requests;
+exports.totals = totals;
+exports.isSubmitting = isSubmitting;
 exports.requestComments = requestComments;
 exports.submitComment = submitComment;
 
@@ -110,7 +115,7 @@ function requests() {
 		case COMMENTS_REQUEST:
 		case COMMENTS_REQUEST_SUCCESS:
 		case COMMENTS_REQUEST_FAILURE:
-			return Object.assign({}, state[action.postId], _defineProperty({}, action.postId, COMMENTS_REQUEST === action.type));
+			return Object.assign({}, state, _defineProperty({}, action.postId, COMMENTS_REQUEST === action.type));
 		default:
 			return state;
 	}
@@ -131,12 +136,12 @@ function totals() {
 
 	switch (action.type) {
 		case COMMENTS_REQUEST_SUCCESS:
-			return Object.assign({}, state[action.postId], _defineProperty({}, action.postId, action.count));
+			return Object.assign({}, state, _defineProperty({}, action.postId, action.count));
 		case COMMENT_SUBMIT_REQUEST_SUCCESS:
 			if (!state[action.postId]) {
-				return Object.assign({}, state[action.postId], _defineProperty({}, action.postId, 1));
+				return Object.assign({}, state, _defineProperty({}, action.postId, 1));
 			}
-			return Object.assign({}, state[action.postId], _defineProperty({}, action.postId, parseInt(state[action.postId], 10) + 1));
+			return Object.assign({}, state, _defineProperty({}, action.postId, parseInt(state[action.postId], 10) + 1));
 		default:
 			return state;
 	}
@@ -159,7 +164,7 @@ function isSubmitting() {
 		case COMMENT_SUBMIT_REQUEST:
 		case COMMENT_SUBMIT_REQUEST_SUCCESS:
 		case COMMENT_SUBMIT_REQUEST_FAILURE:
-			return Object.assign({}, state[action.postId], _defineProperty({}, action.postId, COMMENT_SUBMIT_REQUEST === action.type));
+			return Object.assign({}, state, _defineProperty({}, action.postId, COMMENT_SUBMIT_REQUEST === action.type));
 		default:
 			return state;
 	}
@@ -225,7 +230,7 @@ function submitComment(comment) {
 			postId: comment.post
 		});
 
-		api.post('/wp/v2/comments', comment).then(function (data) {
+		return submitCommentRequest(comment).then(function (data) {
 			dispatch({
 				type: COMMENT_SUBMIT_REQUEST_SUCCESS,
 				comment: data,
@@ -269,5 +274,39 @@ function requestPageCount(url) {
 		body: null
 	}).then(function (response) {
 		return parseInt(response.headers.get('X-WP-TotalPages'), 10) || 1;
+	});
+}
+
+// Helper to submit the comment with nonce header
+function submitCommentRequest(data) {
+	var url = api.config.url + 'wp-json/wp/v2/comments';
+
+	var headers = {
+		'Accept': 'application/json',
+		'X-WP-Nonce': SiteSettings.nonce,
+		'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+	};
+
+	return fetch(url, {
+		method: 'POST',
+		headers: headers,
+		body: _qs2.default.stringify(data),
+		mode: 'same-origin',
+		credentials: 'include'
+	}).then(function (response) {
+		return response.text().then(function (text) {
+			var json = void 0;
+			try {
+				json = JSON.parse(text);
+			} catch (e) {
+				throw { message: text, code: response.status };
+			}
+
+			if (response.status >= 300) {
+				throw json;
+			} else {
+				return json;
+			}
+		});
 	});
 }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
   "dependencies": {
     "debug": "^2.2.0",
     "lodash": "^4.17.2",
+    "qs": "^6.3.0",
     "react": "^15.3.2",
     "react-redux": "^4.4.5",
     "redux": "^3.6.0",
     "shallowequal": "^0.2.2",
-    "wpapi": "^0.11.0"
+    "wordpress-rest-api-oauth-1": "^1.0.8"
   },
   "engines": {
     "node": ">=0.10"

--- a/src/state.js
+++ b/src/state.js
@@ -158,7 +158,7 @@ export function requestComments( postId ) {
 		};
 
 		api.get( '/wp/v2/comments', query ).then( comments => {
-			requestPageCount( '/wp/v2/comments', query ).then( count => {
+			requestCommentCount( '/wp/v2/comments', query ).then( count => {
 				dispatch( {
 					type: COMMENTS_REQUEST_SUCCESS,
 					comments,
@@ -208,8 +208,8 @@ export function submitComment( comment ) {
 	};
 }
 
-// Helper to grab the page count off the header
-function requestPageCount( url, data = null ) {
+// Helper to grab the total comment count off the header
+function requestCommentCount( url, data = null ) {
 	if ( url.indexOf( 'http' ) !== 0 ) {
 		url = `${api.config.url}wp-json${url}`
 	}
@@ -232,7 +232,7 @@ function requestPageCount( url, data = null ) {
 		body: null
 	} )
 	.then( response => {
-		return parseInt( response.headers.get( 'X-WP-TotalPages' ), 10 ) || 1;
+		return parseInt( response.headers.get( 'X-WP-Total' ), 10 );
 	} );
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -4,7 +4,11 @@
  */
 import { combineReducers } from 'redux';
 import keyBy from 'lodash/keyBy';
-const site = require( 'wpapi' )( { endpoint: SiteSettings.endpoint, nonce: SiteSettings.nonce } );
+import qs from 'qs';
+import API from 'wordpress-rest-api-oauth-1';
+const api = new API( {
+	url: SiteSettings.endpoint
+} );
 
 /**
  * Comment actions
@@ -148,12 +152,19 @@ export function requestComments( postId ) {
 			postId,
 		} );
 
-		return site.comments().forPost( postId ).order( 'asc' ).then( ( data ) => {
-			dispatch( {
-				type: COMMENTS_REQUEST_SUCCESS,
-				comments: data,
-				count: data._paging.total,
-				postId
+		const query = {
+			order: 'asc',
+			post: postId,
+		};
+
+		api.get( '/wp/v2/comments', query ).then( comments => {
+			requestPageCount( '/wp/v2/comments', query ).then( count => {
+				dispatch( {
+					type: COMMENTS_REQUEST_SUCCESS,
+					comments,
+					count,
+					postId
+				} );
 			} );
 			return null;
 		} ).catch( ( error ) => {
@@ -179,7 +190,7 @@ export function submitComment( comment ) {
 			postId: comment.post,
 		} );
 
-		return site.comments().post( comment ).then( ( data ) => {
+		api.post( '/wp/v2/comments', comment ).then( ( data ) => {
 			dispatch( {
 				type: COMMENT_SUBMIT_REQUEST_SUCCESS,
 				comment: data,
@@ -195,4 +206,32 @@ export function submitComment( comment ) {
 			return error;
 		} );
 	};
+}
+
+// Helper to grab the page count off the header
+function requestPageCount( url, data = null ) {
+	if ( url.indexOf( 'http' ) !== 0 ) {
+		url = `${api.config.url}wp-json${url}`
+	}
+
+	if ( data ) {
+		// must be decoded before being passed to ouath
+		url += `?${decodeURIComponent( qs.stringify( data ) )}`;
+		data = null
+	}
+
+	const headers = {
+		'Accept': 'application/json',
+		'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+	};
+
+	return fetch( url, {
+		method: 'HEAD',
+		headers: headers,
+		mode: 'cors',
+		body: null
+	} )
+	.then( response => {
+		return parseInt( response.headers.get( 'X-WP-TotalPages' ), 10 ) || 1;
+	} );
 }

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -28,7 +28,7 @@ import commentsOn1 from './fixtures/forPost1';
 import commentsOn149 from './fixtures/forPost149';
 import comment from './fixtures/single';
 
-describe( 'Post reducer', () => {
+describe( 'Comment reducer', () => {
 	describe( 'items', () => {
 		it( 'should have no change by default', () => {
 			const newState = items( undefined, {} );

--- a/test/selectors.js
+++ b/test/selectors.js
@@ -10,7 +10,6 @@ import keyBy from 'lodash/keyBy';
  */
 import * as selectors from '../src/selectors';
 import commentsOn1 from './fixtures/forPost1';
-// import single from './fixtures/single';
 
 const commentsById = keyBy( commentsOn1, 'id' );
 
@@ -34,7 +33,7 @@ const state = deepFreeze( {
 	}
 } );
 
-describe( 'Post selectors', function() {
+describe( 'Comment selectors', function() {
 	it( 'should contain isRequestingCommentsForPost method', function() {
 		expect( selectors.isRequestingCommentsForPost ).to.be.a( 'function' );
 	} );


### PR DESCRIPTION
I'm not using the oauth functionality here, but perhaps by switching it can be easier for others to implement if they need. It's also a more straightforward implementation, making it easier to react to changes in the core API (like the loss of `filter`).